### PR TITLE
fix: wn_cross blink wnsignal.json

### DIFF
--- a/src/main/resources/assets/opensignals/modeldefinitions/wnsignal.json
+++ b/src/main/resources/assets/opensignals/modeldefinitions/wnsignal.json
@@ -83,7 +83,8 @@
                 {
                     "blockstate":"hasandis(WNTYPE) && with(WNCROSS.BLINK)",
                     "retexture":{
-                        "lamp_1": "lamp_white_blink"
+                        "lamp_1_north":"lamp_white_blink",
+                        "lamp_1_south":"lamp_white_blink",                        
                     }
                 }
             ]


### PR DESCRIPTION
The blinking light was forgotten in the last update.  
I have seen this and have fixed it. 