### PR TITLE
Added Highlighting of Linked Signals

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
     if: endswith(github.ref_name, 'master') && github.ref_protected && github.ref_type == 'branch'
     runs-on: ubuntu-latest
     env:
-      APPVEYOR_BUILD_VERSION: '3.7.1'
+      APPVEYOR_BUILD_VERSION: '3.7.2'
       CURSETOKEN: ${{ secrets.CURSETOKEN }}
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ logs
 
 # Files from Forge MDK
 forge*changelog.txt
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,22 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'java'
 
 apply plugin: "com.matthewprenger.cursegradle"
 
 sourceSets{
     main {
         java {
-            srcDirs("guilib/src/", "linkableapi/src/", "contentPackLib/src")
+            srcDirs("src/main/java", "guilib/src/", "linkableapi/src/", "contentPackLib/src")
         }
     }
+}
+repositories {
+    maven {
+            name = "SquidDev"
+            url = "https://squiddev.cc/maven/"
+        }
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
@@ -79,6 +86,9 @@ dependencies {
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2860'
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //implementation files('libs/cc-tweaked-1.12.2-1.89.2.jar')
+    compileOnly "org.squiddev:cc-tweaked-1.12.2:1.89.2"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,9 @@ apply plugin: "com.matthewprenger.cursegradle"
 sourceSets{
     main {
         java {
-            srcDirs("src/main/java", "guilib/src/", "linkableapi/src/", "contentPackLib/src")
+            srcDirs("src/main/", "guilib/src/", "linkableapi/src/", "contentPackLib/src")
         }
     }
-}
-repositories {
-    maven {
-            name = "SquidDev"
-            url = "https://squiddev.cc/maven/"
-        }
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
@@ -86,9 +80,6 @@ dependencies {
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2860'
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    //implementation files('libs/cc-tweaked-1.12.2-1.89.2.jar')
-    compileOnly "org.squiddev:cc-tweaked-1.12.2:1.89.2"
 }
 
 test {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.12.2 - 3.7.2]
+* feat: added Linked Signal Highlighting to Signal Box and Controller
+* ref: updated guilib
+
 ## [1.12.2 - 3.7.1]
 * fix: render bounding box
 * fix: animation is not signalblock

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "Open-Signals"

--- a/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
+++ b/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
@@ -59,6 +59,13 @@ public class OpenSignalsMain {
         MinecraftForge.EVENT_BUS.register(SignalBoxHandler.class);
         debug = true;
         log = LoggerContext.getContext().getLogger(MODID);
+
+        contentPacks = new ContentPackHandler(MODID, "assets/" + MODID, log, name -> {
+            final Optional<Path> path = getRessourceLocation(name);
+            if (path.isPresent())
+                return path.get().toAbsolutePath();
+            return Paths.get("");
+        });
     }
 
     @SidedProxy(serverSide = "com.troblecodings.signals.proxy.CommonProxy", //
@@ -87,12 +94,7 @@ public class OpenSignalsMain {
     public void preinit(final FMLPreInitializationEvent event) {
         debug = Files.isDirectory(event.getSourceFile().toPath());
         log = event.getModLog();
-        contentPacks = new ContentPackHandler(MODID, "assets/" + MODID, log, name -> {
-            final Optional<Path> path = getRessourceLocation(name);
-            if (path.isPresent())
-                return path.get().toAbsolutePath();
-            return Paths.get("");
-        });
+
         proxy.initModEvent(event);
     }
 

--- a/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
+++ b/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
@@ -57,14 +57,6 @@ public class OpenSignalsMain {
         MinecraftForge.EVENT_BUS.register(NameHandler.class);
         MinecraftForge.EVENT_BUS.register(SignalStateHandler.class);
         MinecraftForge.EVENT_BUS.register(SignalBoxHandler.class);
-        debug = true;
-        log = LoggerContext.getContext().getLogger(MODID);
-        contentPacks = new ContentPackHandler(MODID, "assets/" + MODID, log, name -> {
-            final Optional<Path> path = getRessourceLocation(name);
-            if (path.isPresent())
-                return path.get().toAbsolutePath();
-            return Paths.get("");
-        });
     }
 
     @SidedProxy(serverSide = "com.troblecodings.signals.proxy.CommonProxy", //
@@ -93,6 +85,12 @@ public class OpenSignalsMain {
     public void preinit(final FMLPreInitializationEvent event) {
         debug = Files.isDirectory(event.getSourceFile().toPath());
         log = event.getModLog();
+        contentPacks = new ContentPackHandler(MODID, "assets/" + MODID, log, name -> {
+            final Optional<Path> path = getRessourceLocation(name);
+            if (path.isPresent())
+                return path.get().toAbsolutePath();
+            return Paths.get("");
+        });
         proxy.initModEvent(event);
     }
 

--- a/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
+++ b/src/main/java/com/troblecodings/signals/OpenSignalsMain.java
@@ -57,6 +57,8 @@ public class OpenSignalsMain {
         MinecraftForge.EVENT_BUS.register(NameHandler.class);
         MinecraftForge.EVENT_BUS.register(SignalStateHandler.class);
         MinecraftForge.EVENT_BUS.register(SignalBoxHandler.class);
+        debug = true;
+        log = LoggerContext.getContext().getLogger(MODID);
     }
 
     @SidedProxy(serverSide = "com.troblecodings.signals.proxy.CommonProxy", //

--- a/src/main/java/com/troblecodings/signals/blocks/SignalController.java
+++ b/src/main/java/com/troblecodings/signals/blocks/SignalController.java
@@ -43,10 +43,12 @@ public class SignalController extends BasicBlock {
 
                     final SignalControllerTileEntity controller = (SignalControllerTileEntity) tile;
 
-                    if (controller.hasLink())
+                    if (controller.hasLink()) {
+                        ClientRenderUpdate.INSTANCE.clearHighlights();
                         ClientRenderUpdate.INSTANCE.addHighlight(controller.getLinkedPosition());
-                    else
+                    } else {
                         playerIn.sendMessage(new TextComponentString("No Link"));
+                    }
                 }
                 return true;
             } else {

--- a/src/main/java/com/troblecodings/signals/blocks/SignalController.java
+++ b/src/main/java/com/troblecodings/signals/blocks/SignalController.java
@@ -3,6 +3,7 @@ package com.troblecodings.signals.blocks;
 import java.util.Optional;
 
 import com.troblecodings.signals.OpenSignalsMain;
+import com.troblecodings.signals.handler.ClientRenderUpdate;
 import com.troblecodings.signals.core.TileEntitySupplierWrapper;
 import com.troblecodings.signals.init.OSItems;
 import com.troblecodings.signals.tileentitys.SignalControllerTileEntity;
@@ -16,6 +17,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 
 public class SignalController extends BasicBlock {
@@ -32,10 +34,25 @@ public class SignalController extends BasicBlock {
             final EnumFacing facing, final float hitX, final float hitY, final float hitZ) {
         final Item item = playerIn.getHeldItemMainhand().getItem();
         if (!(item.equals(OSItems.LINKING_TOOL) || item.equals(OSItems.MULTI_LINKING_TOOL))) {
-            if (worldIn.isRemote)
+            if (playerIn.isSneaking()) {
+                if (worldIn.isRemote) {
+                    final TileEntity tile = worldIn.getTileEntity(pos);
+
+                    if (!(tile instanceof SignalControllerTileEntity))
+                        return false;
+
+                    final SignalControllerTileEntity controller = (SignalControllerTileEntity) tile;
+
+                    if (controller.hasLink())
+                        ClientRenderUpdate.INSTANCE.addHighlight(controller.getLinkedPosition());
+                    else
+                        playerIn.sendMessage(new TextComponentString("No Link"));
+                }
                 return true;
-            OpenSignalsMain.handler.invokeGui(SignalController.class, playerIn, worldIn, pos,
-                    "signalcontroller");
+            } else {
+                OpenSignalsMain.handler.invokeGui(SignalController.class, playerIn, worldIn, pos,
+                        "signalcontroller");
+            }
             return true;
         }
         return false;

--- a/src/main/java/com/troblecodings/signals/blocks/SignalController.java
+++ b/src/main/java/com/troblecodings/signals/blocks/SignalController.java
@@ -32,24 +32,26 @@ public class SignalController extends BasicBlock {
     public boolean onBlockActivated(final World worldIn, final BlockPos pos,
             final IBlockState state, final EntityPlayer playerIn, final EnumHand hand,
             final EnumFacing facing, final float hitX, final float hitY, final float hitZ) {
+        if (worldIn.isRemote)
+            return true;
+
         final Item item = playerIn.getHeldItemMainhand().getItem();
         if (!(item.equals(OSItems.LINKING_TOOL) || item.equals(OSItems.MULTI_LINKING_TOOL))) {
             if (playerIn.isSneaking()) {
-                if (worldIn.isRemote) {
-                    final TileEntity tile = worldIn.getTileEntity(pos);
+                final TileEntity tile = worldIn.getTileEntity(pos);
 
-                    if (!(tile instanceof SignalControllerTileEntity))
-                        return false;
+                if (!(tile instanceof SignalControllerTileEntity))
+                    return false;
 
-                    final SignalControllerTileEntity controller = (SignalControllerTileEntity) tile;
+                final SignalControllerTileEntity controller = (SignalControllerTileEntity) tile;
 
-                    if (controller.hasLink()) {
-                        ClientRenderUpdate.INSTANCE.clearHighlights();
-                        ClientRenderUpdate.INSTANCE.addHighlight(controller.getLinkedPosition());
-                    } else {
-                        playerIn.sendMessage(new TextComponentString("No Link"));
-                    }
+                if (controller.hasLink()) {
+                    ClientRenderUpdate.INSTANCE.clearHighlights();
+                    ClientRenderUpdate.INSTANCE.addHighlight(controller.getLinkedPosition());
+                } else {
+                    playerIn.sendMessage(new TextComponentString("No Link"));
                 }
+
                 return true;
             } else {
                 OpenSignalsMain.handler.invokeGui(SignalController.class, playerIn, worldIn, pos,
@@ -58,6 +60,7 @@ public class SignalController extends BasicBlock {
             return true;
         }
         return false;
+
     }
 
     @Override

--- a/src/main/java/com/troblecodings/signals/config/ConfigHandler.java
+++ b/src/main/java/com/troblecodings/signals/config/ConfigHandler.java
@@ -78,6 +78,10 @@ public final class ConfigHandler {
     @Comment("Change the render distance for animated signals. Default: 128")
     public static int renderDistance = 128;
 
+    @Name("highlight duration")
+    @Comment("Change the duration of the highlight. Default: 10 (seconds)")
+    public static int highlightDuration = 10;
+
     @Name("Debug Mode")
     @Comment("Toggle debug mode.")
     public static boolean debugMode = false;

--- a/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
+++ b/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
@@ -500,6 +500,7 @@ public class GuiSignalBox extends GuiBase {
             layout.add(icon);
 
             layout.add(GuiElements.createButton(name, e -> {
+                ClientRenderUpdate.INSTANCE.clearHighlights();
                 ClientRenderUpdate.INSTANCE.addHighlight(p);
             }));
             layout.add(GuiElements.createButton("x", 20, e -> {

--- a/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
+++ b/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
@@ -67,7 +67,6 @@ import com.troblecodings.signals.signalbox.entrys.PathEntryType;
 import com.troblecodings.signals.signalbox.entrys.PathOptionEntry;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
@@ -499,10 +498,11 @@ public class GuiSignalBox extends GuiBase {
             icon.add(new UIToolTip(I18Wrapper.format("type." + t.name())));
             layout.add(icon);
 
-            layout.add(GuiElements.createButton(name, e -> {
-                ClientRenderUpdate.INSTANCE.clearHighlights();
+            UIEntity btn = GuiElements.createButton(name, e -> {
                 ClientRenderUpdate.INSTANCE.addHighlight(p);
-            }));
+            });
+            btn.add(new UIToolTip(I18Wrapper.format("sb.highlight")));
+            layout.add(btn);
             layout.add(GuiElements.createButton("x", 20, e -> {
                 removeBlockPos(p);
                 list.remove(layout);

--- a/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
+++ b/src/main/java/com/troblecodings/signals/guis/GuiSignalBox.java
@@ -55,6 +55,7 @@ import com.troblecodings.signals.enums.ShowTypes;
 import com.troblecodings.signals.enums.SignalBoxNetwork;
 import com.troblecodings.signals.enums.SignalBoxPage;
 import com.troblecodings.signals.handler.ClientNameHandler;
+import com.troblecodings.signals.handler.ClientRenderUpdate;
 import com.troblecodings.signals.signalbox.MainSignalIdentifier;
 import com.troblecodings.signals.signalbox.MainSignalIdentifier.SignalState;
 import com.troblecodings.signals.signalbox.ModeSet;
@@ -66,6 +67,7 @@ import com.troblecodings.signals.signalbox.entrys.PathEntryType;
 import com.troblecodings.signals.signalbox.entrys.PathOptionEntry;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
@@ -77,17 +79,16 @@ public class GuiSignalBox extends GuiBase {
     public static final int GRID_COLOR = 0xFF5B5B5B;
     public static final int EDIT_COLOR = 0x5000A2FF;
     public static final int OUTPUT_COLOR = 0xffff00;
-    public static final int TRAIN_NUMBER_BACKGROUND_COLOR =
-            ConfigHandler.signalboxTrainnumberBackgroundColor;
+    public static final int TRAIN_NUMBER_BACKGROUND_COLOR = ConfigHandler.signalboxTrainnumberBackgroundColor;
 
-    public static final ResourceLocation REDSTONE_OFF =
-            new ResourceLocation(OpenSignalsMain.MODID, "gui/textures/redstone_off.png");
-    public static final ResourceLocation REDSTONE_OFF_BLOCKED =
-            new ResourceLocation(OpenSignalsMain.MODID, "gui/textures/redstone_off_blocked.png");
-    public static final ResourceLocation REDSTONE_ON =
-            new ResourceLocation(OpenSignalsMain.MODID, "gui/textures/redstone_on.png");
-    public static final ResourceLocation REDSTONE_ON_BLOCKED =
-            new ResourceLocation(OpenSignalsMain.MODID, "gui/textures/redstone_on_blocked.png");
+    public static final ResourceLocation REDSTONE_OFF = new ResourceLocation(OpenSignalsMain.MODID,
+            "gui/textures/redstone_off.png");
+    public static final ResourceLocation REDSTONE_OFF_BLOCKED = new ResourceLocation(OpenSignalsMain.MODID,
+            "gui/textures/redstone_off_blocked.png");
+    public static final ResourceLocation REDSTONE_ON = new ResourceLocation(OpenSignalsMain.MODID,
+            "gui/textures/redstone_on.png");
+    public static final ResourceLocation REDSTONE_ON_BLOCKED = new ResourceLocation(OpenSignalsMain.MODID,
+            "gui/textures/redstone_on_blocked.png");
 
     private static final float[] ALL_LINES = getLines();
     protected static final int TILE_WIDTH = 10;
@@ -239,8 +240,7 @@ public class GuiSignalBox extends GuiBase {
 
     public static String getSignalInfo(final BlockPos signalPos, final LinkType type) {
         final Minecraft mc = Minecraft.getMinecraft();
-        final String customName =
-                ClientNameHandler.getClientName(new StateInfo(mc.world, signalPos));
+        final String customName = ClientNameHandler.getClientName(new StateInfo(mc.world, signalPos));
         return String.format("%s (x=%d, y=%d. z=%d)", customName == null
                 ? (type.equals(LinkType.SIGNAL) ? "" : I18Wrapper.format("type." + type.name()))
                 : customName, signalPos.getX(), signalPos.getY(), signalPos.getZ());
@@ -254,9 +254,9 @@ public class GuiSignalBox extends GuiBase {
         helpPage.helpUsageMode(null);
         this.resetTileSelection();
 
-        final MainSignalIdentifier identifier =
-                new MainSignalIdentifier(new ModeIdentifier(holder.point, holder.modeSet), pos,
-                        SignalState.combine(entry.enumValue.getSubsidiaryShowType()));
+        final MainSignalIdentifier identifier = new MainSignalIdentifier(
+                new ModeIdentifier(holder.point, holder.modeSet), pos,
+                SignalState.combine(entry.enumValue.getSubsidiaryShowType()));
         final List<MainSignalIdentifier> greenSignals = container.greenSignals
                 .computeIfAbsent(identifier.getPoint(), _u -> new ArrayList<>());
         greenSignals.remove(identifier);
@@ -388,8 +388,7 @@ public class GuiSignalBox extends GuiBase {
         nameEntity.setHeight(20);
         nameEntity.add(new UIBox(UIBox.HBOX, 5));
 
-        final UIEntity labelEntity =
-                GuiElements.createLabel(I18Wrapper.format("info.node.text"), 1.25f);
+        final UIEntity labelEntity = GuiElements.createLabel(I18Wrapper.format("info.node.text"), 1.25f);
         labelEntity.setInheritWidth(false);
         labelEntity.setWidth(100);
         nameEntity.add(labelEntity);
@@ -500,7 +499,9 @@ public class GuiSignalBox extends GuiBase {
             icon.add(new UIToolTip(I18Wrapper.format("type." + t.name())));
             layout.add(icon);
 
-            layout.add(GuiElements.createButton(name));
+            layout.add(GuiElements.createButton(name, e -> {
+                ClientRenderUpdate.INSTANCE.addHighlight(p);
+            }));
             layout.add(GuiElements.createButton("x", 20, e -> {
                 removeBlockPos(p);
                 list.remove(layout);
@@ -571,8 +572,7 @@ public class GuiSignalBox extends GuiBase {
                 bottomEntity.add(menu);
                 bottomEntity.getParent().update();
             });
-            final UIEntity buttonNo =
-                    GuiElements.createButton(I18Wrapper.format("btn.no"), e -> pop());
+            final UIEntity buttonNo = GuiElements.createButton(I18Wrapper.format("btn.no"), e -> pop());
             buttons.setInherits(true);
             final UIBox vbox = new UIBox(UIBox.HBOX, 1);
             buttons.add(vbox);
@@ -681,8 +681,7 @@ public class GuiSignalBox extends GuiBase {
                 this::initializePageSettings));
         header.add(
                 GuiElements.createButton(I18Wrapper.format("btn.edit"), this::initializeFieldEdit));
-        mainButton =
-                GuiElements.createButton(I18Wrapper.format("btn.main"), this::initializeFieldUsage);
+        mainButton = GuiElements.createButton(I18Wrapper.format("btn.main"), this::initializeFieldUsage);
         header.add(mainButton);
         resetSelection(mainButton);
 

--- a/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
+++ b/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
@@ -4,7 +4,6 @@ import com.troblecodings.guilib.ecs.entitys.DrawInfo;
 import com.troblecodings.signals.config.ConfigHandler;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.AxisAlignedBB;

--- a/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
+++ b/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
@@ -1,7 +1,7 @@
 package com.troblecodings.signals.handler;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.troblecodings.guilib.ecs.entitys.DrawInfo;
+import com.troblecodings.signals.config.ConfigHandler;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -15,42 +15,51 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class ClientRenderUpdate {
 
     public static final ClientRenderUpdate INSTANCE = new ClientRenderUpdate();
-    private final Map<BlockPos, Long> highlightedBlocks = new HashMap<>();
+
+    private BlockPos pos;
+    private long time;
 
     public void addHighlight(final BlockPos pos) {
-        highlightedBlocks.put(pos, System.currentTimeMillis() + 10000);
+        this.pos = pos;
+        this.time = System.currentTimeMillis() + ConfigHandler.highlightDuration * 1000;
     }
 
     public void clearHighlights() {
-        highlightedBlocks.clear();
+        this.pos = null;
+        this.time = 0;
     }
 
     @SubscribeEvent
     public void render(final RenderWorldLastEvent event) {
-        if (highlightedBlocks.isEmpty())
+        if (this.pos == null)
             return;
         final long current = System.currentTimeMillis();
-        highlightedBlocks.entrySet().removeIf(entry -> entry.getValue() < current);
+        if (current > this.time) {
+            this.pos = null;
+            this.time = 0;
+            return;
+        }
 
         final Entity player = Minecraft.getMinecraft().getRenderViewEntity();
         if (player == null)
             return;
 
-        final double doubleX = player.lastTickPosX + (player.posX - player.lastTickPosX) * event.getPartialTicks();
-        final double doubleY = player.lastTickPosY + (player.posY - player.lastTickPosY) * event.getPartialTicks();
-        final double doubleZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * event.getPartialTicks();
+        final float partialTicks = event.getPartialTicks();
+        final double doubleX = player.lastTickPosX + (player.posX - player.lastTickPosX) * partialTicks;
+        final double doubleY = player.lastTickPosY + (player.posY - player.lastTickPosY) * partialTicks;
+        final double doubleZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * partialTicks;
 
-        GlStateManager.pushMatrix();
-        GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
-        GlStateManager.disableDepth();
-        GlStateManager.disableTexture2D();
+        DrawInfo drawInfo = new DrawInfo(0, 0, partialTicks);
 
-        highlightedBlocks.forEach((pos, time) -> {
-            RenderGlobal.drawSelectionBoundingBox(new AxisAlignedBB(pos), 1, 0, 0, 1);
-        });
+        drawInfo.push();
+        drawInfo.translate(-doubleX, -doubleY, -doubleZ);
+        drawInfo.disableTexture();
+        drawInfo.depthOff();
 
-        GlStateManager.enableTexture2D();
-        GlStateManager.enableDepth();
-        GlStateManager.popMatrix();
+        RenderGlobal.drawSelectionBoundingBox(new AxisAlignedBB(this.pos), 1, 0, 0, 1);
+
+        drawInfo.depthOn();
+        drawInfo.enableTexture(); // TODO: add a drawInfo method for this!
+        drawInfo.pop();
     }
 }

--- a/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
+++ b/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
@@ -3,7 +3,10 @@ package com.troblecodings.signals.handler;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
@@ -29,7 +32,7 @@ public class ClientRenderUpdate {
         final long current = System.currentTimeMillis();
         highlightedBlocks.entrySet().removeIf(entry -> entry.getValue() < current);
 
-        final net.minecraft.entity.Entity player = net.minecraft.client.Minecraft.getMinecraft().getRenderViewEntity();
+        final Entity player = Minecraft.getMinecraft().getRenderViewEntity();
         if (player == null)
             return;
 
@@ -37,17 +40,17 @@ public class ClientRenderUpdate {
         final double doubleY = player.lastTickPosY + (player.posY - player.lastTickPosY) * event.getPartialTicks();
         final double doubleZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * event.getPartialTicks();
 
-        net.minecraft.client.renderer.GlStateManager.pushMatrix();
-        net.minecraft.client.renderer.GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
-        net.minecraft.client.renderer.GlStateManager.disableDepth();
-        net.minecraft.client.renderer.GlStateManager.disableTexture2D();
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
+        GlStateManager.disableDepth();
+        GlStateManager.disableTexture2D();
 
         highlightedBlocks.forEach((pos, time) -> {
             RenderGlobal.drawSelectionBoundingBox(new AxisAlignedBB(pos), 1, 0, 0, 1);
         });
 
-        net.minecraft.client.renderer.GlStateManager.enableTexture2D();
-        net.minecraft.client.renderer.GlStateManager.enableDepth();
-        net.minecraft.client.renderer.GlStateManager.popMatrix();
+        GlStateManager.enableTexture2D();
+        GlStateManager.enableDepth();
+        GlStateManager.popMatrix();
     }
 }

--- a/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
+++ b/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
@@ -18,6 +18,10 @@ public class ClientRenderUpdate {
         highlightedBlocks.put(pos, System.currentTimeMillis() + 10000);
     }
 
+    public void clearHighlights() {
+        highlightedBlocks.clear();
+    }
+
     @SubscribeEvent
     public void render(final RenderWorldLastEvent event) {
         if (highlightedBlocks.isEmpty())

--- a/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
+++ b/src/main/java/com/troblecodings/signals/handler/ClientRenderUpdate.java
@@ -1,0 +1,49 @@
+package com.troblecodings.signals.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class ClientRenderUpdate {
+
+    public static final ClientRenderUpdate INSTANCE = new ClientRenderUpdate();
+    private final Map<BlockPos, Long> highlightedBlocks = new HashMap<>();
+
+    public void addHighlight(final BlockPos pos) {
+        highlightedBlocks.put(pos, System.currentTimeMillis() + 10000);
+    }
+
+    @SubscribeEvent
+    public void render(final RenderWorldLastEvent event) {
+        if (highlightedBlocks.isEmpty())
+            return;
+        final long current = System.currentTimeMillis();
+        highlightedBlocks.entrySet().removeIf(entry -> entry.getValue() < current);
+
+        final net.minecraft.entity.Entity player = net.minecraft.client.Minecraft.getMinecraft().getRenderViewEntity();
+        if (player == null)
+            return;
+
+        final double doubleX = player.lastTickPosX + (player.posX - player.lastTickPosX) * event.getPartialTicks();
+        final double doubleY = player.lastTickPosY + (player.posY - player.lastTickPosY) * event.getPartialTicks();
+        final double doubleZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * event.getPartialTicks();
+
+        net.minecraft.client.renderer.GlStateManager.pushMatrix();
+        net.minecraft.client.renderer.GlStateManager.translate(-doubleX, -doubleY, -doubleZ);
+        net.minecraft.client.renderer.GlStateManager.disableDepth();
+        net.minecraft.client.renderer.GlStateManager.disableTexture2D();
+
+        highlightedBlocks.forEach((pos, time) -> {
+            RenderGlobal.drawSelectionBoundingBox(new AxisAlignedBB(pos), 1, 0, 0, 1);
+        });
+
+        net.minecraft.client.renderer.GlStateManager.enableTexture2D();
+        net.minecraft.client.renderer.GlStateManager.enableDepth();
+        net.minecraft.client.renderer.GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/com/troblecodings/signals/proxy/ClientProxy.java
+++ b/src/main/java/com/troblecodings/signals/proxy/ClientProxy.java
@@ -15,6 +15,7 @@ import com.troblecodings.signals.guis.GuiPathwayRequester;
 import com.troblecodings.signals.guis.GuiSignalBridge;
 import com.troblecodings.signals.guis.GuiTrainNumber;
 import com.troblecodings.signals.handler.ClientNameHandler;
+import com.troblecodings.signals.handler.ClientRenderUpdate;
 import com.troblecodings.signals.handler.ClientSignalStateHandler;
 import com.troblecodings.signals.handler.NameHandler;
 import com.troblecodings.signals.handler.SignalStateHandler;
@@ -50,5 +51,6 @@ public class ClientProxy extends CommonProxy {
         ClientRegistry.bindTileEntitySpecialRenderer(SignalTileEntity.class,
                 new SignalSpecialRenderer());
         MinecraftForge.EVENT_BUS.register(OSModels.class);
+        MinecraftForge.EVENT_BUS.register(ClientRenderUpdate.INSTANCE);
     }
 }

--- a/src/main/java/com/troblecodings/signals/signalbridge/SignalBridgeBuilder.java
+++ b/src/main/java/com/troblecodings/signals/signalbridge/SignalBridgeBuilder.java
@@ -153,7 +153,7 @@ public class SignalBridgeBuilder {
         final List<NBTWrapper> signalList = new ArrayList<>();
         vecForSignal.forEach((entry, vec) -> {
             final NBTWrapper tag = new NBTWrapper();
-            vec.writeNBT(tag);
+            vec.write(tag);
             tag.putString(SIGNALS_ON_BRIDGE, entry.getValue().getRegistryName().getResourcePath());
             tag.putString(CUSTOMNAME, entry.getKey());
             signalList.add(tag);

--- a/src/main/java/com/troblecodings/signals/tileentitys/SignalControllerTileEntity.java
+++ b/src/main/java/com/troblecodings/signals/tileentitys/SignalControllerTileEntity.java
@@ -29,6 +29,7 @@ import com.troblecodings.signals.handler.SignalStateInfo;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -131,6 +132,11 @@ public class SignalControllerTileEntity extends SyncableTileEntity
 
     public void setProfileRSInput(final byte profileRSInput) {
         this.profileRSInput = profileRSInput;
+    }
+
+    @Override
+    public SPacketUpdateTileEntity getUpdatePacket() {
+        return new SPacketUpdateTileEntity(getPos(), 1, getUpdateTag());
     }
 
     @Override

--- a/src/main/java/com/troblecodings/signals/tileentitys/SignalControllerTileEntity.java
+++ b/src/main/java/com/troblecodings/signals/tileentitys/SignalControllerTileEntity.java
@@ -263,6 +263,7 @@ public class SignalControllerTileEntity extends SyncableTileEntity
             linkedSignalPosition = pos;
             linkedSignal = (Signal) block;
             onLoad();
+            this.syncClient();
             return true;
         } else if (block instanceof RedstoneInput) {
             linkedRSInput = pos;
@@ -286,6 +287,7 @@ public class SignalControllerTileEntity extends SyncableTileEntity
         linkedSignal = null;
         allStates.clear();
         enabledStates.clear();
+        this.syncClient();
         return true;
     }
 

--- a/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
+++ b/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
@@ -28,11 +28,6 @@ public class SyncableTileEntity extends BasicBlockEntity {
     }
 
     @Override
-    public SPacketUpdateTileEntity getUpdatePacket() {
-        return new SPacketUpdateTileEntity(getPos(), 1, getUpdateTag());
-    }
-
-    @Override
     public void onDataPacket(final NetworkManager net, final SPacketUpdateTileEntity pkt) {
         handleUpdateTag(pkt.getNbtCompound());
     }

--- a/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
+++ b/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
@@ -22,7 +22,9 @@ public class SyncableTileEntity extends BasicBlockEntity {
 
     @Override
     public NBTTagCompound getUpdateTag() {
-        return this.writeToNBT(new NBTTagCompound());
+        final NBTWrapper wrapper = new NBTWrapper();
+        saveWrapper(wrapper);
+        return wrapper.tag;
     }
 
     @Override

--- a/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
+++ b/src/main/java/com/troblecodings/signals/tileentitys/SyncableTileEntity.java
@@ -8,6 +8,8 @@ import com.troblecodings.guilib.ecs.interfaces.UIClientSync;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.world.World;
 
 public class SyncableTileEntity extends BasicBlockEntity {
@@ -20,9 +22,17 @@ public class SyncableTileEntity extends BasicBlockEntity {
 
     @Override
     public NBTTagCompound getUpdateTag() {
-        final NBTWrapper wrapper = new NBTWrapper();
-        saveWrapper(wrapper);
-        return wrapper.tag;
+        return this.writeToNBT(new NBTTagCompound());
+    }
+
+    @Override
+    public SPacketUpdateTileEntity getUpdatePacket() {
+        return new SPacketUpdateTileEntity(getPos(), 1, getUpdateTag());
+    }
+
+    @Override
+    public void onDataPacket(final NetworkManager net, final SPacketUpdateTileEntity pkt) {
+        handleUpdateTag(pkt.getNbtCompound());
     }
 
     @Override

--- a/src/main/resources/assets/opensignals/blockstates/post.json
+++ b/src/main/resources/assets/opensignals/blockstates/post.json
@@ -1,1 +1,7 @@
-{"variants": {"normal": {"model": "opensignals:post"}}}
+{
+    "variants": {
+        "normal": {
+            "model": "opensignals:post"
+        }
+    }
+}

--- a/src/main/resources/assets/opensignals/lang/de_de.lang
+++ b/src/main/resources/assets/opensignals/lang/de_de.lang
@@ -680,3 +680,4 @@ property.mode_select.name=Wähle Streckenelement
 info.crossing=Kreuzungselement
 property.zs6_state.name=Zs6
 property.zs6_state.desc=Hier kann ausgewählt werden, ob die Fahrstraße ins Gegengleis führt.
+sb.highlight=Clicken um Verlinktes Signal zu markieren

--- a/src/main/resources/assets/opensignals/lang/en_us.lang
+++ b/src/main/resources/assets/opensignals/lang/en_us.lang
@@ -679,3 +679,4 @@ property.mode_select.name=Select track element
 info.crossing=Crossing element
 property.zs6_state.name=Wrong side of track (Zs6)
 property.zs6_state.desc=Here you can select whether the path leads to the wrong side of tracks.
+sb.highlight=Click to highlight linked signal


### PR DESCRIPTION
Added a highlighting feature to the Signal Controller and Signal Box. Linked Signal BaseBlocks will be highlighted with a red box for 10 seconds.

- To highlight a linked signal on a Signal Controller, Shift + Click the Controller.
- To highlight a linked signal on a Signal Box, go to the Linking tab and click the button with the name and coordinates in it.

Only one signal can be highlighted at a time to reduce confusion regarding which signal is currently selected.

Also had to move content pack initialization to preinit, because of crashing when launching the game.
Added settings.gradle  and java plugin (build.gradle:19) to be compatible with VSCode.